### PR TITLE
Correct shebang to use /usr/bin/env node.

### DIFF
--- a/npm-depends.js
+++ b/npm-depends.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 'use strict';
 


### PR DESCRIPTION
/bin/env is not the usual location for the shebang line. Instead use /usr/bin/env.